### PR TITLE
Limit Date Should Not Be Altered During Session

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -26,7 +26,6 @@ Store.prototype.hit = function (req, configuration, callback) {
             var timeLimit = limitDate + configuration.innerTimeLimit;
 
             var resetInner = now > timeLimit;
-            limit.date = now;
 
             self.decreaseLimits(ip, limit, resetInner, configuration, function (error, result) {
                 callback(error, result, limitDate);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-rate-limiter",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Rate limiter middleware for express applications",
   "main": "index.js",
   "author": "Steven Thuriot",


### PR DESCRIPTION
We found a bug where the innerTimeLimit option was not being respected. This was due to a line where the limit (which tracks each session per hit in the store module) object's date property was being reset to the current time on every hit. 

Instead, the date property should only be set if the limit object has not yet been assigned. That date should then remain unchanged for the duration of the allowed session as defined in the configuration. The change here simply removes resetting that date while the session is ongoing (i.e. while limit is still truthy).
